### PR TITLE
Fix a bug that would not cancel

### DIFF
--- a/Sources/CombineAsyncable/Publisher+Task.swift
+++ b/Sources/CombineAsyncable/Publisher+Task.swift
@@ -31,7 +31,7 @@ public extension Publisher where Self.Failure == Never {
         
         let cancellable = self.sink { value in
             task = Task(priority: priority) {
-                try? Task.checkCancellation()
+                guard !Task.isCancelled else { return }
                 await receiveValue(value)
             }
         }


### PR DESCRIPTION
Even if the Task is cancelled, `try? Task.checkCancellation()`  will ignore the `CancellationError` and `await receiveValue(value)` will be executed as usual.